### PR TITLE
Ensure all subscribers are called from push.

### DIFF
--- a/dist/transmitter.js
+++ b/dist/transmitter.js
@@ -17,7 +17,7 @@ function transmitter() {
   };
 
   var push = function push(value) {
-    subscriptions.forEach(function (subscription) {
+    [].concat(subscriptions).forEach(function (subscription) {
       return subscription(value);
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transmitter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "dist/transmitter.js",
   "scripts": {

--- a/src/transmitter.js
+++ b/src/transmitter.js
@@ -13,7 +13,7 @@ function transmitter() {
   }
 
   const push = (value) => {
-    subscriptions.forEach(subscription => subscription(value))
+    [...subscriptions].forEach(subscription => subscription(value))
   }
 
   return { subscribe, push, unsubscribe }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -48,5 +48,17 @@ export default {
   'unlisten dont exist'() {
     const bus = transmitter()
     bus.unsubscribe(function () { })
+  },
+
+  'unsubscribe while pushing'() {
+    const bus = transmitter()
+    const subscription = bus.subscribe(function () { subscription.dispose() })
+    const spy = sinon.spy()
+    bus.subscribe(spy)
+
+    bus.push(1);
+
+    assert(spy.calledOnce, 'spy should be called once.')
+    assert.equal(spy.callCount, 1, 'spy should be called exactly once.')
   }
 }


### PR DESCRIPTION
This fixes issue #1 by making a copy of the array before calling `forEach`. This fix is quite simple, but it _does_ require allocating a new array every time `push` is called.
