### PR TITLE
Ensure all subscribers are called from push. (slightly more complex version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Dead simple pub-sub
 
-It's 22 LOC of just subscribe and push.
+It's 35 LOC of just subscribe and push.
 
 ## API
 

--- a/dist/transmitter.js
+++ b/dist/transmitter.js
@@ -1,11 +1,14 @@
 "use strict";
 
 function transmitter() {
+  var pushDepth = 0;
   var subscriptions = [];
 
   var unsubscribe = function unsubscribe(onChange) {
     var id = subscriptions.indexOf(onChange);
-    if (id >= 0) subscriptions.splice(id, 1);
+    if (id >= 0) {
+      if (pushDepth) subscriptions[id] = null;else subscriptions.splice(id, 1);
+    }
   };
 
   var subscribe = function subscribe(onChange) {
@@ -17,9 +20,17 @@ function transmitter() {
   };
 
   var push = function push(value) {
-    subscriptions.forEach(function (subscription) {
-      return subscription(value);
-    });
+    ++pushDepth;
+    try {
+      subscriptions.forEach(function (subscription) {
+        return subscription && subscription(value);
+      });
+    } finally {
+      if (! --pushDepth) {
+        var id = -1;
+        while ((id = subscriptions.indexOf(null)) >= 0) subscriptions.splice(id, 1);
+      }
+    }
   };
 
   return { subscribe: subscribe, push: push, unsubscribe: unsubscribe };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transmitter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "dist/transmitter.js",
   "scripts": {

--- a/src/transmitter.js
+++ b/src/transmitter.js
@@ -1,9 +1,13 @@
 function transmitter() {
+  let pushDepth = 0
   const subscriptions = []
 
   const unsubscribe = (onChange) => {
     const id = subscriptions.indexOf(onChange)
-    if (id >= 0) subscriptions.splice(id, 1)
+    if (id >= 0) {
+      if (pushDepth) subscriptions[id] = null
+      else subscriptions.splice(id, 1)
+    }
   }
 
   const subscribe = (onChange) => {
@@ -13,7 +17,16 @@ function transmitter() {
   }
 
   const push = (value) => {
-    subscriptions.forEach(subscription => subscription(value))
+    ++pushDepth
+    try {
+      subscriptions.forEach(subscription => subscription && subscription(value))
+    }
+    finally {
+      if (!--pushDepth) {
+        let id = -1
+        while ((id = subscriptions.indexOf(null)) >= 0) subscriptions.splice(id, 1)
+      }
+    }
   }
 
   return { subscribe, push, unsubscribe }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -48,5 +48,17 @@ export default {
   'unlisten dont exist'() {
     const bus = transmitter()
     bus.unsubscribe(function () { })
+  },
+
+  'unsubscribe while pushing'() {
+    const bus = transmitter()
+    const subscription = bus.subscribe(function () { subscription.dispose() })
+    const spy = sinon.spy()
+    bus.subscribe(spy)
+
+    bus.push(1);
+
+    assert(spy.calledOnce, 'spy should be called once.')
+    assert.equal(spy.callCount, 1, 'spy should be called exactly once.')
   }
 }


### PR DESCRIPTION
This fixes issue #1 without the need to allocate a new array with each call to `push`, but it does come at the expense of a few more lines of code
